### PR TITLE
solana: add warning to README for regression with Solana v1.15

### DIFF
--- a/solana/README.md
+++ b/solana/README.md
@@ -12,6 +12,9 @@ Read the design documents for each example project:
 
 ## Getting Started
 
+> **Warning**
+> Known to cause problems with Solana version 1.15 - downgrade to Solana 1.14.14
+
 First, you will need `cargo` and `anchor` CLI tools. If you need these tools,
 please visit the [Anchor book] for more details.
 


### PR DESCRIPTION
When using Solana Tool Suite v1.15.0 Wormhole Initiate test and subsequent tests fails with 'Transaction simulation failed: This program may not be used for executing instructions' which seems to be caused by a mismatch between expecting BPFLoader2 while the program owner is BPFLoaderUpgradeab1e.