### PR TITLE
removing sparse flag to prevent older versions of git from failing

### DIFF
--- a/solana/dependencies/Makefile
+++ b/solana/dependencies/Makefile
@@ -36,7 +36,6 @@ $(network_sos)&: #&: specifies a grouped target
 	  --depth 1 \
 	  --branch main \
 	  --filter=blob:none \
-	  --sparse \
 	  https://github.com/wormhole-foundation/wormhole \
 	  tmp-wormhole > /dev/null 2>&1
 	cd tmp-wormhole; git sparse-checkout set solana > /dev/null 2>&1


### PR DESCRIPTION
addresses #48 

tested with git 2.25.1 (old) and 2.40.1 (current)