### PR TITLE
Solana: Various fixes from debugging session

### DIFF
--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -190,7 +190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75cc8066fbd45e0e03edf48342c79265aa34ca76cefeace48ef6c402b6946665"
 dependencies = [
  "anchor-lang",
- "mpl-token-metadata",
  "solana-program",
  "spl-associated-token-account",
  "spl-token",
@@ -1151,76 +1150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mpl-token-auth-rules"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24dcb2b0ec0e9246f6f035e0336ba3359c21f6928dfd90281999e2c8e8ab53eb"
-dependencies = [
- "borsh",
- "mpl-token-metadata-context-derive",
- "num-derive",
- "num-traits",
- "rmp-serde",
- "serde",
- "shank",
- "solana-program",
- "solana-zk-token-sdk",
- "thiserror",
-]
-
-[[package]]
-name = "mpl-token-metadata"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e674db8846d4a603454ce9c93233dd8d503d62f2afe1b9e6486ce81e431f89"
-dependencies = [
- "arrayref",
- "borsh",
- "mpl-token-auth-rules",
- "mpl-token-metadata-context-derive",
- "mpl-utils",
- "num-derive",
- "num-traits",
- "shank",
- "solana-program",
- "spl-associated-token-account",
- "spl-token",
- "thiserror",
-]
-
-[[package]]
-name = "mpl-token-metadata-context-derive"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12989bc45715b0ee91944855130131479f9c772e198a910c3eb0ea327d5bffc3"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "mpl-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc48e64c50dba956acb46eec86d6968ef0401ef37031426da479f1f2b592066"
-dependencies = [
- "arrayref",
- "borsh",
- "solana-program",
- "spl-token",
-]
-
-[[package]]
-name = "nft-burn-bridging"
-version = "0.1.0"
-dependencies = [
- "anchor-lang",
- "anchor-spl",
- "mpl-token-metadata",
- "wormhole-anchor-sdk",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,28 +1491,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
-name = "rmp"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
-dependencies = [
- "byteorder",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,40 +1662,6 @@ checksum = "e2904bea16a1ae962b483322a1c7b81d976029203aea1f461e51cd7705db7ba9"
 dependencies = [
  "digest 0.10.5",
  "keccak",
-]
-
-[[package]]
-name = "shank"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63e565b5e95ad88ab38f312e89444c749360641c509ef2de0093b49f55974a5"
-dependencies = [
- "shank_macro",
-]
-
-[[package]]
-name = "shank_macro"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63927d22a1e8b74bda98cc6e151fcdf178b7abb0dc6c4f81e0bbf5ffe2fc4ec8"
-dependencies = [
- "proc-macro2",
- "quote",
- "shank_macro_impl",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "shank_macro_impl"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce03403df682f80f4dc1efafa87a4d0cb89b03726d0565e6364bdca5b9a441"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "serde",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2418,6 +2291,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
+ "cfg-if",
 ]
 
 [[package]]

--- a/solana/Makefile
+++ b/solana/Makefile
@@ -74,7 +74,7 @@ endef
 
 #`anchor keys list` generates all keypair files in target/deploy as a side effect if they don't
 # exist hence there's no rule for them yet!
-keys_list_syntax = \([^:]*\):\s*\($(base58_char)*\)
+keys_list_syntax = \([^:]*\): *\($(base58_char)*\)
 anchor_keys_list := $(shell \
   mv -f Anchor.toml Anchor.toml.tmp 2>/dev/null; cp Anchor.toml.base Anchor.toml; \
   anchor keys list | sed 's/^$(keys_list_syntax)$$/\1:\2/'; \

--- a/solana/dependencies/Makefile
+++ b/solana/dependencies/Makefile
@@ -32,6 +32,9 @@ lparen := (
 rparen := )
 $(network_sos)&: #&: specifies a grouped target
 	@echo "> Fetching Solana bridge programs from Wormhole repo"
+	@if [ -d "tmp-wormhole" ]; then  \
+		rm -rf "tmp-wormhole"; \
+	fi
 	git clone \
 	  --depth 1 \
 	  --branch main \

--- a/solana/modules/wormhole-anchor-sdk/Cargo.toml
+++ b/solana/modules/wormhole-anchor-sdk/Cargo.toml
@@ -14,3 +14,4 @@ token-bridge = []
 [dependencies]
 anchor-lang = "0.27.0"
 anchor-spl = "0.27.0"
+cfg-if = "1.0.0"

--- a/solana/modules/wormhole-anchor-sdk/Cargo.toml
+++ b/solana/modules/wormhole-anchor-sdk/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "SDK using Anchor interfaces to interact with Wormhole Solana Programs"
 
 [features]
+default = ["mainnet"]
 mainnet = []
 solana-devnet = []
 tilt-devnet = []

--- a/solana/modules/wormhole-anchor-sdk/src/lib.rs
+++ b/solana/modules/wormhole-anchor-sdk/src/lib.rs
@@ -2,3 +2,6 @@ pub mod wormhole;
 
 #[cfg(feature = "token-bridge")]
 pub mod token_bridge;
+
+#[macro_use]
+extern crate cfg_if;

--- a/solana/modules/wormhole-anchor-sdk/src/token_bridge/program.rs
+++ b/solana/modules/wormhole-anchor-sdk/src/token_bridge/program.rs
@@ -1,13 +1,14 @@
 use anchor_lang::prelude::*;
 
-#[cfg(feature = "mainnet")]
-declare_id!("wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb");
-
-#[cfg(feature = "solana-devnet")]
-declare_id!("DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe");
-
-#[cfg(feature = "tilt-devnet")]
-declare_id!("B6RHG3mfcckmrYN1UhmJzyS1XX3fZKbkeUcpJe9Sy3FE");
+cfg_if! {
+    if #[cfg(feature = "mainnet")] {
+        declare_id!("wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb");
+    } else if #[cfg(feature = "solana-devnet")] {
+        declare_id!("DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe");
+    } else if #[cfg(feature = "tilt-devnet")] {
+        declare_id!("B6RHG3mfcckmrYN1UhmJzyS1XX3fZKbkeUcpJe9Sy3FE");
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct TokenBridge;

--- a/solana/modules/wormhole-anchor-sdk/src/wormhole/program.rs
+++ b/solana/modules/wormhole-anchor-sdk/src/wormhole/program.rs
@@ -1,13 +1,14 @@
 use anchor_lang::prelude::*;
 
-#[cfg(feature = "mainnet")]
-declare_id!("worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth");
-
-#[cfg(feature = "solana-devnet")]
-declare_id!("3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5");
-
-#[cfg(feature = "tilt-devnet")]
-declare_id!("Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o");
+cfg_if! {
+    if #[cfg(feature = "mainnet")] {
+        declare_id!("worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth");
+    } else if #[cfg(feature = "solana-devnet")] {
+        declare_id!("3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5");
+    } else if #[cfg(feature = "tilt-devnet")]{
+        declare_id!("Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o");
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct Wormhole;

--- a/solana/programs/01_hello_world/Cargo.toml
+++ b/solana/programs/01_hello_world/Cargo.toml
@@ -20,4 +20,4 @@ default = []
 
 [dependencies]
 anchor-lang = { version="0.27.0", features = ["init-if-needed"]}
-wormhole-anchor-sdk = { path = "../../modules/wormhole-anchor-sdk" }
+wormhole-anchor-sdk = { path = "../../modules/wormhole-anchor-sdk" , default-features = false }

--- a/solana/programs/02_hello_token/Cargo.toml
+++ b/solana/programs/02_hello_token/Cargo.toml
@@ -21,4 +21,4 @@ default = []
 [dependencies]
 anchor-lang = { version="0.27.0", features = ["init-if-needed"]}
 anchor-spl = "0.27.0"
-wormhole-anchor-sdk = { path = "../../modules/wormhole-anchor-sdk", features = ["token-bridge"]}
+wormhole-anchor-sdk = { path = "../../modules/wormhole-anchor-sdk", default-features = false, features = ["token-bridge"]}


### PR DESCRIPTION
Makefile:
If for some reason the clone/build fails (like docker not running) the tmp dir will hang around and fail further attempts.
Replaced `\s` with ` ` (space literal) since mac `sed` command does not respect the `\s` 

Module:
Set a default feature of `mainnet` in `Cargo.toml` and added `cfg_if` to execute the `declare_id` macro conditionally