### PR TITLE
Add config.toml in cargo config to provide path to program id file

### DIFF
--- a/solana/.cargo/config.toml
+++ b/solana/.cargo/config.toml
@@ -1,0 +1,4 @@
+[env]
+NFT_BURN_BRIDGING_PROGRAM_ID_FILE = "../../../target/deploy/nft_burn_bridging-program_id.bin"
+HELLO_WORLD_PROGRAM_ID_FILE = "../../../target/deploy/hello_world-program_id.bin"
+HELLO_TOKEN_PROGRAM_ID_FILE = "../../../target/deploy/hello_token-program_id.bin"


### PR DESCRIPTION
The `env!` macro in each Solana program's `lib.rs` meant to read in the program id file complains:

![image](https://github.com/wormhole-foundation/wormhole-scaffolding/assets/520236/cac51d59-3788-4aab-af06-06909687c1f0)

Adding a `.cargo/config.toml` with the path to the bin gives the `env` macro something to look at.
