### PR TITLE
Fix post message

### DIFF
--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -773,7 +773,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
- "wormhole-anchor-sdk 0.1.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wormhole-anchor-sdk 0.1.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -781,7 +781,7 @@ name = "hello-world"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wormhole-anchor-sdk 0.1.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wormhole-anchor-sdk 0.1.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1111,7 +1111,7 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "mpl-token-metadata",
- "wormhole-anchor-sdk 0.1.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wormhole-anchor-sdk 0.1.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "wormhole-anchor-sdk"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2229,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "wormhole-anchor-sdk"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1789eb9fd2113b6e2945cb67123b902141a9bfde1ec33762be58447eb2431f6"
+checksum = "dd5b515d674db0fd7b562bc6ecd1b3e35912e6a9a101f486513b8978205736a2"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/solana/modules/wormhole-anchor-sdk/Cargo.toml
+++ b/solana/modules/wormhole-anchor-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wormhole-anchor-sdk"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 description = "SDK using Anchor interfaces to interact with Wormhole Solana Programs"
 edition = "2021"
 authors = ["W7"]

--- a/solana/modules/wormhole-anchor-sdk/src/wormhole/instructions.rs
+++ b/solana/modules/wormhole-anchor-sdk/src/wormhole/instructions.rs
@@ -61,8 +61,8 @@ pub fn post_message<'info>(
             AccountMeta::new(ctx.accounts.payer.key(), true),
             AccountMeta::new(ctx.accounts.fee_collector.key(), false),
             AccountMeta::new_readonly(ctx.accounts.clock.key(), false),
-            AccountMeta::new_readonly(ctx.accounts.rent.key(), false),
             AccountMeta::new_readonly(ctx.accounts.system_program.key(), false),
+            AccountMeta::new_readonly(ctx.accounts.rent.key(), false),
         ],
         data: Instruction::PostMessage {
             batch_id,

--- a/solana/programs/01_hello_world/Cargo.toml
+++ b/solana/programs/01_hello_world/Cargo.toml
@@ -20,4 +20,4 @@ default = []
 
 [dependencies]
 anchor-lang = { version = "0.28.0", features = ["init-if-needed"]}
-wormhole-anchor-sdk = { version = "0.1.0-alpha.1", default-features = false }
+wormhole-anchor-sdk = { version = "0.1.0-alpha.2", default-features = false }

--- a/solana/programs/02_hello_token/Cargo.toml
+++ b/solana/programs/02_hello_token/Cargo.toml
@@ -21,4 +21,4 @@ default = []
 [dependencies]
 anchor-lang = { version = "0.28.0", features = ["init-if-needed"]}
 anchor-spl = "0.28.0"
-wormhole-anchor-sdk = { version = "0.1.0-alpha.1", default-features = false, features = ["token-bridge"]}
+wormhole-anchor-sdk = { version = "0.1.0-alpha.2", default-features = false, features = ["token-bridge"]}

--- a/solana/programs/03_nft_burn_bridging/Cargo.toml
+++ b/solana/programs/03_nft_burn_bridging/Cargo.toml
@@ -22,4 +22,4 @@ default = []
 anchor-lang = { version = "0.28.0", features=["init-if-needed"]}
 anchor-spl = { version = "0.28.0", features = [ "metadata" ] }
 mpl-token-metadata = { version = "1.9.0", features = [ "no-entrypoint" ] }
-wormhole-anchor-sdk = { version = "0.1.0-alpha.1", default-features = false }
+wormhole-anchor-sdk = { version = "0.1.0-alpha.2", default-features = false }


### PR DESCRIPTION
It doesn't matter which order the system program and rent are passed in when creating the account metas vector. But if the account context in the core bridge were to change to take a more rigid form, it will resemble the change made here (since this is how accounts are ordered when the Token Bridge invokes the post message instruction for its outbound transfers).

Published a new release with version 0.1.0-alpha.2.